### PR TITLE
Consecutive URLs

### DIFF
--- a/1.0/jquery.linkify-1.0.js
+++ b/1.0/jquery.linkify-1.0.js
@@ -69,8 +69,8 @@
 
 (function($){
 
-  var noProtocolUrl = /(^|["'(\s]|&lt;)(www\..+?\..+?)((?:[:?]|\.+)?(?:\s|$)|&gt;|[)"',])/g,
-      httpOrMailtoUrl = /(^|["'(\s]|&lt;)((?:(?:https?|ftp):\/\/|mailto:).+?)((?:[:?]|\.+)?(?:\s|$)|&gt;|[)"',])/g,
+  var noProtocolUrl = /(^|["'(\s]|&lt;)(www\..+?\..+?)((?:[:?]|\.+)?(?=(?:\s|$)|&gt;|[)"',]))/g,
+      httpOrMailtoUrl = /(^|["'(\s]|&lt;)((?:(?:https?|ftp):\/\/|mailto:).+?)((?:[:?]|\.+)?(?=(?:\s|$)|&gt;|[)"',]))/g,
       linkifier = function ( html ) {
           return html
                       .replace( noProtocolUrl, '$1<a href="<``>://$2">$2</a>$3' )  // NOTE: we escape `"http` as `"<``>` to make sure `httpOrMailtoUrl` below doesn't find it as a false-positive
@@ -184,7 +184,7 @@
   linkify.plugins = {
       // default mailto: plugin
       mailto: {
-          re: /(^|["'(\s]|&lt;)([^"'(\s&]+?@.+\.[a-z]{2,7})(([:?]|\.+)?(\s|$)|&gt;|[)"',])/gi,
+          re: /(^|["'(\s]|&lt;)([^"'(\s&]+?@.+\.[a-z]{2,7})(([:?]|\.+)?(?=(\s|$)|&gt;|[)"',]))/gi,
           tmpl: '$1<a href="mailto:$2">$2</a>$3'
         }
     };


### PR DESCRIPTION
This should fix the issue where linkify doesn't parse consecutive URLs. I've used positive lookahead to prevent the regex from including the trailing space in the match.
